### PR TITLE
Add vscode launch task to allow for debugging generate_synoptic.py

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,14 +5,11 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Debug Unit Test",
+            "name": "Run Generate Synoptic",
             "type": "debugpy",
             "request": "launch",
-            "justMyCode": false,
-            "program": "${file}",
-            "purpose": [
-                "debug-test"
-            ],
+            "justMyCode": true,
+            "program": "${workspaceFolder}/example-synoptic/generate_synoptic.py",
             "console": "integratedTerminal",
             "env": {
                 // Enable break on exception when debugging tests (see: tests/conftest.py)


### PR DESCRIPTION
With this, you can just head to the "Run and Debug" tab in vscode to run `generate_synoptic.py` with the "Run Generate Synoptic" task. This also allow for adding breakpoints in the editor.