### PR TITLE
Move gui_map reading into generate.py

### DIFF
--- a/src/techui_builder/builder.py
+++ b/src/techui_builder/builder.py
@@ -47,8 +47,6 @@ class Builder:
         # Requires beamline has already been read from create_gui.yaml
         self._services_dir = Path(f"{self.beamline.dom}-services/services")
 
-        self._read_gui_map()
-
     def _extract_from_create_gui(self):
         """
         Extracts from the create_gui.yaml file to generate
@@ -108,17 +106,8 @@ class Builder:
                     )
                     self.entities[new_entity.P].append(new_entity)
 
-    def _read_gui_map(self):
-        """Read the gui_map.yaml file from techui-support."""
-        gui_map = self.create_gui.parent.absolute().joinpath(
-            "../techui-support/gui_map.yaml"
-        )
-
-        with open(gui_map) as map:
-            self._gui_map = yaml.safe_load(map)
-
     def _generate_screen(self, screen_name: str, screen_components: list[Entity]):
-        generator = Generator(screen_components, self._gui_map, screen_name)
+        generator = Generator(screen_components, screen_name)
         generator.build_groups()
         generator.write_screen(self._write_directory)
 

--- a/src/techui_builder/generate.py
+++ b/src/techui_builder/generate.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
 
+import yaml
 from lxml import etree, objectify  # type: ignore
 from phoebusgen import screen as Screen
 from phoebusgen import widget as Widget
@@ -15,10 +16,10 @@ from techui_builder.objects import Entity
 class Generator:
     screen_components: list[Entity]
     # TODO: Fix type of screen
-    gui_map: dict
     screen_name: str
 
     # These are global params for the class (not accessible by user)
+    gui_map: dict = field(init=False, repr=False)
     default_size: int = field(default=100, init=False, repr=False)
     P: str = field(default="P", init=False, repr=False)
     M: str = field(default="M", init=False, repr=False)
@@ -32,6 +33,18 @@ class Generator:
     widget_x: int = field(default=0, init=False, repr=False)
     widget_count: int = field(default=0, init=False, repr=False)
     group_padding: int = field(default=50, init=False, repr=False)
+
+    def __post_init__(self):
+        self._read_gui_map()
+
+    def _read_gui_map(self):
+        """Read the gui_map.yaml file from techui-support."""
+        gui_map = Path(__file__).parent.parent.joinpath(
+            "../techui-support/gui_map.yaml"
+        )
+
+        with open(gui_map) as map:
+            self.gui_map = yaml.safe_load(map)
 
     def _get_screen_dimensions(self, file: str) -> tuple[int, int]:
         """


### PR DESCRIPTION
the gui_map.yaml from `techui-support` is only used by generate.py, so moving the logic from builder.py into there.