### PR TITLE
Added motion controller as extra for M3 summary

### DIFF
--- a/example-synoptic/create_gui.yaml
+++ b/example-synoptic/create_gui.yaml
@@ -137,6 +137,8 @@ components:
 
   M3:
     prefix: BL23B-OP-MR-03
+    extras:
+      - BL23B-MO-PMAC-01
 
   # ----- MOD -----
 


### PR DESCRIPTION
We'd the motor summaries to have motors and their corresponding motor controller in one group.