### PR TITLE
Changed Ionp size to remove scroll bars

### DIFF
--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -87,7 +87,6 @@ def test_gb_extract_entities(gb: Builder, index, type, desc, P, M, R):
 def test_setup(gb: Builder):
     gb._services_dir = Path(f"example/{gb.beamline.dom}-services/services")
     gb._write_directory = Path("example/data")
-    gb.setup()
     gb.generate_screens()
 
     with open(f"./{gb._write_directory}/motor.bob") as f:

--- a/tests/test_files/motor.bob
+++ b/tests/test_files/motor.bob
@@ -5,115 +5,50 @@
       <name>motor</name>
       <x>0</x>
       <y>0</y>
-      <width>610</width>
-      <height>770</height>
-      <widget type="embedded" version="2.0.0">
-        <name>pmac.autohome</name>
-        <width>205</width>
-        <height>120</height>
-        <file>../../src/techui_support/bob/pmacUtil/motor_embed.bob</file>
-        <macros>
-          <P>BL01T-MO-MAP-01:STAGE</P>
-        </macros>
-        <x>0</x>
-        <y>0</y>
-      </widget>
+      <width>255</width>
+      <height>470</height>
       <widget type="embedded" version="2.0.0">
         <name>X</name>
         <width>205</width>
         <height>120</height>
-        <file>../../src/techui_support/bob/pmacUtil/motor_embed.bob</file>
+        <file>../../src/techui_support/bob/pmac/motor_embed.bob</file>
         <macros>
           <P>BL01T-MO-MAP-01:STAGE</P>
           <M>X</M>
         </macros>
         <x>0</x>
-        <y>150</y>
+        <y>0</y>
       </widget>
       <widget type="embedded" version="2.0.0">
         <name>A</name>
         <width>205</width>
         <height>120</height>
-        <file>../../src/techui_support/bob/pmacUtil/motor_embed.bob</file>
+        <file>../../src/techui_support/bob/pmac/motor_embed.bob</file>
         <macros>
           <P>BL01T-MO-MAP-01:STAGE</P>
           <M>A</M>
         </macros>
+        <x>0</x>
+        <y>150</y>
+      </widget>
+      <widget type="action_button" version="2.0.0">
+        <name>pmac.GeoBrick</name>
+        <width>100</width>
+        <height>40</height>
+        <pv_name>BL01T-MO-BRICK-01:None</pv_name>
+        <text>BL01T-MO-BRICK-01</text>
+        <actions>
+          <action type="open_display">
+            <description>Open Display</description>
+            <macros>
+              <P>BL01T-MO-BRICK-01</P>
+            </macros>
+            <file>../../src/techui_support/bob/pmac/pmacController.bob</file>
+            <target>tab</target>
+          </action>
+        </actions>
         <x>0</x>
         <y>300</y>
-      </widget>
-      <widget type="embedded" version="2.0.0">
-        <name>pmac.autohome</name>
-        <width>205</width>
-        <height>120</height>
-        <file>../../src/techui_support/bob/pmacUtil/motor_embed.bob</file>
-        <macros>
-          <P>BL01T-MO-MAP-01:STAGE</P>
-        </macros>
-        <x>0</x>
-        <y>450</y>
-      </widget>
-      <widget type="embedded" version="2.0.0">
-        <name>X</name>
-        <width>205</width>
-        <height>120</height>
-        <file>../../src/techui_support/bob/pmacUtil/motor_embed.bob</file>
-        <macros>
-          <P>BL01T-MO-MAP-01:STAGE</P>
-          <M>X</M>
-        </macros>
-        <x>0</x>
-        <y>600</y>
-      </widget>
-      <widget type="embedded" version="2.0.0">
-        <name>A</name>
-        <width>205</width>
-        <height>120</height>
-        <file>../../src/techui_support/bob/pmacUtil/motor_embed.bob</file>
-        <macros>
-          <P>BL01T-MO-MAP-01:STAGE</P>
-          <M>A</M>
-        </macros>
-        <x>235</x>
-        <y>0</y>
-      </widget>
-      <widget type="action_button" version="2.0.0">
-        <name>pmac.GeoBrick</name>
-        <width>100</width>
-        <height>40</height>
-        <pv_name>BL01T-MO-BRICK-01:None</pv_name>
-        <text>BL01T-MO-BRICK-01</text>
-        <actions>
-          <action type="open_display">
-            <description>Open Display</description>
-            <macros>
-              <P>BL01T-MO-BRICK-01</P>
-            </macros>
-            <file>../../src/techui_support/bob/pmac/pmacController.bob</file>
-            <target>tab</target>
-          </action>
-        </actions>
-        <x>235</x>
-        <y>150</y>
-      </widget>
-      <widget type="action_button" version="2.0.0">
-        <name>pmac.GeoBrick</name>
-        <width>100</width>
-        <height>40</height>
-        <pv_name>BL01T-MO-BRICK-01:None</pv_name>
-        <text>BL01T-MO-BRICK-01</text>
-        <actions>
-          <action type="open_display">
-            <description>Open Display</description>
-            <macros>
-              <P>BL01T-MO-BRICK-01</P>
-            </macros>
-            <file>../../src/techui_support/bob/pmac/pmacController.bob</file>
-            <target>tab</target>
-          </action>
-        </actions>
-        <x>355</x>
-        <y>150</y>
       </widget>
     </widget>
   </display>


### PR DESCRIPTION
The Ionpump vacuum screen displays with scroll bars when it isn't needed. This change modifies techui-support ionp screen bob file to fit the screen to widget dimensions and set the placement of the screen to the origin point.