### PR TITLE
Adding a warning when the prefix in the create_gui.yaml doesn't match

### DIFF
--- a/src/techui_builder/builder.py
+++ b/src/techui_builder/builder.py
@@ -133,6 +133,11 @@ class Builder:
                         screen_entities.extend(self.entities[extra_p])
 
                 self._generate_screen(component.name, screen_entities)
+            else:
+                LOGGER.warning(
+                    f"{self.create_gui.name}: The prefix set in {component.name} does \
+not match any P field in the ioc.yaml files in services"
+                )
 
     def _generate_json_map(
         self, file_path: Path, visited: set[Path] | None = None


### PR DESCRIPTION
In create gui, a component can be assigned a prefix that doesn't match any of the fetched Ps from all the IOC.yaml files in services, this should give a warning that the creator of the create_gui file has defined an unmatching prefix that will not enable the screen to be created.