### PR TITLE
Improve json map

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dev = [
     "ruff",
     "tox-uv",
     "twine",
+    "types-lxml",
     "types-mock",
     "uv~=0.8.5",
 ]

--- a/src/techui_builder/autofill.py
+++ b/src/techui_builder/autofill.py
@@ -3,9 +3,10 @@ import os
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from lxml import etree, objectify  # type: ignore
+from lxml import objectify
+from lxml.objectify import ObjectifiedElement
 
-from techui_builder.builder import Builder
+from techui_builder.builder import Builder, _get_action_group
 from techui_builder.objects import Component
 
 LOGGER = logging.getLogger(__name__)
@@ -17,9 +18,8 @@ class Autofiller:
     macros: list[str] = field(default_factory=lambda: ["prefix", "desc", "file"])
 
     def read_bob(self) -> None:
-        parser = etree.XMLParser()
         # Read the bob file
-        self.tree: etree._ElementTree = objectify.parse(self.path, parser)
+        self.tree = objectify.parse(self.path)
 
         # Find the root tag (in this case: <display version="2.0.0">)
         self.root = self.tree.getroot()
@@ -31,14 +31,11 @@ class Autofiller:
         # Loop over objects in the xml
         # i.e. every tag below <display version="2.0.0">
         # but not any nested tags below them
-        for child in self.root:
-            # For type hinting
-            assert isinstance(child, etree._Element)  # noqa: SLF001
-
+        for child in self.root.iterchildren():
             # If widget is a symbol (i.e. a component)
             if child.tag == "widget" and child.get("type", default=None) == "symbol":
                 # Extract it's name
-                symbol_name = child.find("name", namespaces=None).text
+                symbol_name = child.name
 
                 # If the name exists in the component list
                 if symbol_name in comp_names:
@@ -64,32 +61,29 @@ class Autofiller:
         LOGGER.debug(f"Screen filled for {filename}")
 
     def _sub_macro(
-        self, tag_name: str, macro: str, element: etree._Element, current_macro: str
+        self,
+        tag_name: str,
+        macro: str,
+        element: ObjectifiedElement,
+        current_macro: str,
     ) -> None:
         # Extract it's current tag text, or if empty set to $(<macro>)
-        old: str = element.find(tag_name, namespaces=None).text or f"$({macro})"
+        old: str = (
+            el.text
+            if (el := element.find(tag_name)) is not None and el.text is not None
+            else f"$({macro})"
+        )
 
         # Replace instance of {<macro>} with the component's corresponding attribute
         new: str = old.replace(f"$({macro})", current_macro)
 
         # Set component's tag text to the autofilled macro
-        element.find(tag_name, namespaces=None).text = new
+        element[tag_name] = new
 
-    def replace_macros(self, widget: etree._Element, component: Component):
-        # File and desc are under the "actions",
-        # so the corresponding tag needs to be found
-        def _get_action_group(element: etree._Element) -> etree._Element:
-            actions: etree._Element = element.find("actions", namespaces=None)
-            for action in actions.iterchildren("action"):
-                if action.get("type", default=None) == "open_display":
-                    return action
-
-            # TODO: Find better way of handling there being no "actions" group
-            raise Exception(f"Actions group not found in component: {component.name}")
-
+    def replace_macros(self, widget: ObjectifiedElement, component: Component):
         for macro in self.macros:
             # Get current component attribute
-            component_attr = getattr(component, f"{macro}")
+            component_attr = getattr(component, macro)
             # If it is None, then it was not provided so ignore
             if component_attr is None and macro != "desc":
                 continue
@@ -109,6 +103,13 @@ class Autofiller:
                     current_widget = _get_action_group(widget)
                 case _:
                     raise ValueError("The provided macro type is not supported.")
+
+            if current_widget is None:
+                LOGGER.debug(
+                    f"Skipping replace_macros for {component.name} as no action\
+ group found"
+                )
+                continue
 
             self._sub_macro(
                 tag_name=tag_name,

--- a/src/techui_builder/autofill.py
+++ b/src/techui_builder/autofill.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -49,6 +50,11 @@ class Autofiller:
                     self.replace_macros(widget=child, component=comp)
 
     def write_bob(self, filename: Path):
+        # Check if data/ dir exists and if not, make it
+        data_dir = filename.parent
+        if not data_dir.exists():
+            os.mkdir(data_dir)
+
         self.tree.write(
             filename,
             pretty_print=True,  # type: ignore

--- a/src/techui_builder/builder.py
+++ b/src/techui_builder/builder.py
@@ -289,9 +289,13 @@ def _serialise_json_map(map: json_map) -> dict[str, Any]:
 # File and desc are under the "actions",
 # so the corresponding tag needs to be found
 def _get_action_group(element: ObjectifiedElement) -> ObjectifiedElement | None:
-    actions = element.actions
-    assert actions is not None
-    for action in actions.iterchildren("action"):
-        if action.get("type", default=None) == "open_display":
-            return action
-    return None
+    try:
+        actions = element.actions
+        assert actions is not None
+        for action in actions.iterchildren("action"):
+            if action.get("type", default=None) == "open_display":
+                return action
+        return None
+    except AttributeError:
+        # TODO: Find better way of handling there being no "actions" group
+        LOGGER.error(f"Actions group not found in component: {element.text}")

--- a/src/techui_builder/builder.py
+++ b/src/techui_builder/builder.py
@@ -159,6 +159,17 @@ files in services"
     def _generate_json_map(
         self, screen_path: Path, dest_path: Path, visited: set[Path] | None = None
     ) -> json_map:
+        def _get_macros(element: ObjectifiedElement):
+            if hasattr(element, "macros"):
+                macros = element.macros.getchildren()
+                if macros is not None:
+                    return {
+                        str(macro.tag): macro.text
+                        for macro in macros
+                        if macro.text is not None
+                    }
+            return {}
+
         if visited is None:
             visited = set()
 
@@ -196,17 +207,10 @@ files in services"
                             continue
                         file_elem = open_display.file
 
-                        if hasattr(open_display, "macros"):
-                            macros = open_display.macros.getchildren()
-                            if macros is not None:
-                                macro_dict = {
-                                    str(macro.tag): macro.text
-                                    for macro in macros
-                                    if macro.text is not None
-                                }
-
+                        macro_dict = _get_macros(open_display)
                     case "embedded":
                         file_elem = widget_elem.file
+                        macro_dict = _get_macros(widget_elem)
                     case _:
                         continue
 

--- a/src/techui_builder/builder.py
+++ b/src/techui_builder/builder.py
@@ -6,8 +6,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-import lxml.etree as etree
 import yaml
+from lxml import etree, objectify
+from lxml.objectify import ObjectifiedElement
 
 from techui_builder.generate import Generator
 from techui_builder.objects import Beamline, Component, Entity
@@ -166,8 +167,8 @@ files in services"
         node: json_map = {"file": str(screen_path), "children": []}
 
         try:
-            tree = etree.parse(abs_path, None)
-            root: etree._ElementTree = tree.getroot()
+            tree: etree._ElementTree = objectify.parse(abs_path, etree.XMLParser())
+            root: ObjectifiedElement = tree.getroot()
 
             # Find all <file> elements
             for file_elem in root.findall(".//file", namespaces=None):
@@ -183,12 +184,18 @@ files in services"
 
                 # Obtain macros associated with file_elem
                 macro_dict: dict[str, str] = {}
-                widget: etree._Element = file_elem.getparent()
+                widget: ObjectifiedElement | None = file_elem.getparent()
                 if widget is not None:
-                    macros: etree._Element = widget.find("macros", namespaces=None)
+                    macros: ObjectifiedElement | None = widget.find(
+                        "macros", namespaces=None
+                    )
                     if macros is not None:
-                        p: etree._Element = macros.find(".//P", namespaces=None)
-                        m: etree._Element = macros.find(".//M", namespaces=None)
+                        p: ObjectifiedElement | None = macros.find(
+                            ".//P", namespaces=None
+                        )
+                        m: ObjectifiedElement | None = macros.find(
+                            ".//M", namespaces=None
+                        )
                         if p is not None and p.text:
                             macro_dict["P"] = p.text
                         if m is not None and m.text:

--- a/src/techui_builder/generate.py
+++ b/src/techui_builder/generate.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 import yaml
-from lxml import etree, objectify  # type: ignore
+from lxml import objectify
 from phoebusgen import screen as Screen
 from phoebusgen import widget as Widget
 from phoebusgen.widget.widgets import ActionButton, EmbeddedDisplay, Group
@@ -57,11 +57,10 @@ class Generator:
         Parses the bob files for information on the height
         and width of the screen
         """
-        parser = etree.XMLParser()
         # Read the bob file
-        tree: etree._ElementTree = objectify.parse(file, parser)
-        root: etree._Element = tree.getroot()
-        height_element: etree._Element | None = root.find("height", namespaces=None)
+        tree = objectify.parse(file)
+        root = tree.getroot()
+        height_element = root.height
         if height_element is not None:
             height = (
                 self.default_size if (val := height_element.text) is None else int(val)
@@ -70,7 +69,7 @@ class Generator:
             height = self.default_size
             assert "Could not obtain the size of the widget"
 
-        width_element: etree._Element | None = root.find("width", namespaces=None)
+        width_element = root.width
         if width_element is not None:
             width = (
                 self.default_size if (val := width_element.text) is None else int(val)
@@ -89,8 +88,8 @@ class Generator:
         and width of the widget
         """
         # Read the bob file
-        root: etree._Element = etree.fromstring(str(widget), None)
-        height_element: etree._Element | None = root.find("height", namespaces=None)
+        root = objectify.fromstring(str(widget))
+        height_element = root.height
         if height_element is not None:
             height = (
                 self.default_size if (val := height_element.text) is None else int(val)
@@ -99,7 +98,7 @@ class Generator:
             height = self.default_size
             assert "Could not obtain the size of the widget"
 
-        width_element: etree._Element | None = root.find("width", namespaces=None)
+        width_element = root.width
         if width_element is not None:
             width = (
                 self.default_size if (val := width_element.text) is None else int(val)
@@ -118,15 +117,15 @@ class Generator:
         and x of the widget
         """
         # Read the bob file
-        root: etree._Element = etree.fromstring(str(object), None)
-        y_element: etree._Element | None = root.find("y", namespaces=None)
+        root = objectify.fromstring(str(object))
+        y_element = root.y
         if y_element is not None:
             y = self.default_size if (val := y_element.text) is None else int(val)
         else:
             y = self.default_size
             assert "Could not obtain the size of the widget"
 
-        x_element: etree._Element | None = root.find("x", namespaces=None)
+        x_element = root.x
         if x_element is not None:
             x = self.default_size if (val := x_element.text) is None else int(val)
         else:
@@ -146,8 +145,8 @@ class Generator:
         height_list: list[int] = []
         width_list: list[int] = []
         for widget in widget_list:
-            root = etree.fromstring(str(widget), None)
-            x: etree._Element | None = root.find("x")
+            root = objectify.fromstring(str(widget))
+            x = root.x
             if x is not None:
                 x_list.append(
                     self.default_size if (val := x.text) is None else int(val)
@@ -155,7 +154,7 @@ class Generator:
             else:
                 x_list.append(self.default_size)
 
-            height: etree._Element | None = root.find("height")
+            height = root.height
             if height is not None:
                 height_list.append(
                     self.default_size if (val := height.text) is None else int(val)
@@ -163,7 +162,7 @@ class Generator:
             else:
                 height_list.append(self.default_size)
 
-            width: etree._Element | None = root.find("width")
+            width = root.width
             if width is not None:
                 width_list.append(
                     self.default_size if (val := width.text) is None else int(val)
@@ -171,7 +170,7 @@ class Generator:
             else:
                 width_list.append(self.default_size)
 
-            y: etree._Element | None = root.find("y")
+            y = root.y
             if y is not None:
                 y_list.append(
                     self.default_size if (val := y.text) is None else int(val)

--- a/uv.lock
+++ b/uv.lock
@@ -24,6 +24,19 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.13.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/2e/3e5079847e653b1f6dc647aa24549d68c6addb4c595cc0d902d1b19308ad/beautifulsoup4-4.13.5.tar.gz", hash = "sha256:5e70131382930e7c3de33450a2f54a63d5e4b19386eab43a5b34d594268f3695", size = 622954, upload-time = "2025-08-24T14:06:13.168Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/eb/f4151e0c7377a6e08a38108609ba5cede57986802757848688aeedd1b9e8/beautifulsoup4-4.13.5-py3-none-any.whl", hash = "sha256:642085eaa22233aceadff9c69651bc51e8bf3f874fb6d7104ece2beb24b47c4a", size = 105113, upload-time = "2025-08-24T14:06:14.884Z" },
+]
+
+[[package]]
 name = "build"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -269,6 +282,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/55/66/061ec6689207d54effdff535bbdf85cc380d32dd5377173085812565cf38/cryptography-45.0.6-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:eccddbd986e43014263eda489abbddfbc287af5cddfd690477993dbb31e31016", size = 4449859, upload-time = "2025-08-05T23:58:56.639Z" },
     { url = "https://files.pythonhosted.org/packages/41/ff/e7d5a2ad2d035e5a2af116e1a3adb4d8fcd0be92a18032917a089c6e5028/cryptography-45.0.6-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:550ae02148206beb722cfe4ef0933f9352bab26b087af00e48fdfb9ade35c5b3", size = 4320254, upload-time = "2025-08-05T23:58:58.833Z" },
     { url = "https://files.pythonhosted.org/packages/82/27/092d311af22095d288f4db89fcaebadfb2f28944f3d790a4cf51fe5ddaeb/cryptography-45.0.6-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5b64e668fc3528e77efa51ca70fadcd6610e8ab231e3e06ae2bab3b31c2b8ed9", size = 4554815, upload-time = "2025-08-05T23:59:00.283Z" },
+]
+
+[[package]]
+name = "cssselect"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/0a/c3ea9573b1dc2e151abfe88c7fe0c26d1892fe6ed02d0cdb30f0d57029d5/cssselect-1.3.0.tar.gz", hash = "sha256:57f8a99424cfab289a1b6a816a43075a4b00948c86b4dcf3ef4ee7e15f7ab0c7", size = 42870, upload-time = "2025-03-10T09:30:29.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/58/257350f7db99b4ae12b614a36256d9cc870d71d9e451e79c2dc3b23d7c3c/cssselect-1.3.0-py3-none-any.whl", hash = "sha256:56d1bf3e198080cc1667e137bc51de9cadfca259f03c2d4e09037b3e01e30f0d", size = 18786, upload-time = "2025-03-10T09:30:28.048Z" },
 ]
 
 [[package]]
@@ -1084,6 +1106,15 @@ wheels = [
 ]
 
 [[package]]
+name = "soupsieve"
+version = "2.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/e6/21ccce3262dd4889aa3332e5a119a3491a95e8f60939870a3a035aabac0d/soupsieve-2.8.tar.gz", hash = "sha256:e2dd4a40a628cb5f28f6d4b0db8800b8f581b65bb380b97de22ba5ca8d72572f", size = 103472, upload-time = "2025-08-27T15:39:51.78Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl", hash = "sha256:0cc76456a30e20f5d7f2e14a98a4ae2ee4e5abdc7c5ea0aafe795f344bc7984c", size = 36679, upload-time = "2025-08-27T15:39:50.179Z" },
+]
+
+[[package]]
 name = "techui-builder"
 source = { editable = "." }
 dependencies = [
@@ -1111,6 +1142,7 @@ dev = [
     { name = "ruff" },
     { name = "tox-uv" },
     { name = "twine" },
+    { name = "types-lxml" },
     { name = "types-mock" },
     { name = "uv" },
 ]
@@ -1141,6 +1173,7 @@ dev = [
     { name = "ruff" },
     { name = "tox-uv" },
     { name = "twine" },
+    { name = "types-lxml" },
     { name = "types-mock" },
     { name = "uv", specifier = "~=0.8.5" },
 ]
@@ -1212,6 +1245,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c5/8c/7d682431efca5fd290017663ea4588bf6f2c6aad085c7f108c5dbc316e70/typer-0.16.0.tar.gz", hash = "sha256:af377ffaee1dbe37ae9440cb4e8f11686ea5ce4e9bae01b84ae7c63b87f1dd3b", size = 102625, upload-time = "2025-05-26T14:30:31.824Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/42/3efaf858001d2c2913de7f354563e3a3a2f0decae3efe98427125a8f441e/typer-0.16.0-py3-none-any.whl", hash = "sha256:1f79bed11d4d02d4310e3c1b7ba594183bcedb0ac73b27a9e5f28f6fb5b98855", size = 46317, upload-time = "2025-05-26T14:30:30.523Z" },
+]
+
+[[package]]
+name = "types-html5lib"
+version = "1.1.11.20250809"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/ab/6aa4c487ae6f4f9da5153143bdc9e9b4fbc2b105df7ef8127fb920dc1f21/types_html5lib-1.1.11.20250809.tar.gz", hash = "sha256:7976ec7426bb009997dc5e072bca3ed988dd747d0cbfe093c7dfbd3d5ec8bf57", size = 16793, upload-time = "2025-08-09T03:14:20.819Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/05/328a2d6ecbd8aa3e16512600da78b1fe4605125896794a21824f3cac6f14/types_html5lib-1.1.11.20250809-py3-none-any.whl", hash = "sha256:e5f48ab670ae4cdeafd88bbc47113d8126dcf08318e0b8d70df26ecc13eca9b6", size = 22867, upload-time = "2025-08-09T03:14:20.048Z" },
+]
+
+[[package]]
+name = "types-lxml"
+version = "2025.8.25"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "cssselect" },
+    { name = "types-html5lib" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/3e/a545ece610c1bd9699addd887edfe9477a8f647c4336ba75cfb0561d197c/types_lxml-2025.8.25.tar.gz", hash = "sha256:79b9f5b1f236f937f14fe3add9dc687bd8d4111ca5df58eb9f1bde1a3b032fd5", size = 156126, upload-time = "2025-08-26T06:28:56.793Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/29/c45f567b4142288b8184f073af8f659abd134c21de055f971c65f2d755bd/types_lxml-2025.8.25-py3-none-any.whl", hash = "sha256:d61340e5329e102d3f8d64124e90d50c12c0bfeaa9088d65558279ef4e7138ac", size = 95318, upload-time = "2025-08-26T06:28:54.066Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR aims to rework the json map file generation to make it use a `json_map` _object_ instead of passing around dictionaries to compare to a custom `json_map` _type_. This should make the code more modular (e.g. allowing more than just P and M macros to be included in the macros dictionary), as well as make it more readable.
It has also made `macros` a dictionary inside each element instead of just appending a new key-value pair.
If a value is the same as the default value of the `json_map` object, it is ignored from the serialisation process.

It also includes minor changes such as including type-hinting for `lxml`.