### PR TITLE
refactor: Rework Generator instanciation in Builder

### DIFF
--- a/example/bl01t-services/services/bl01t-mo-ioc-01/config/ioc.yaml
+++ b/example/bl01t-services/services/bl01t-mo-ioc-01/config/ioc.yaml
@@ -33,7 +33,7 @@ entities:
     GRP1: All
     GRP2: X
     GRP3: A
-    P: BL01T-MO-MAP-01:STAGE
+    P: BL01T-MO-MOTOR-01
     PLC: 11
     PmacController: BRICK1
 
@@ -50,7 +50,7 @@ entities:
     LLM: "-25"
     M: :X
     MRES: -0.000125
-    P: BL01T-MO-MAP-01:STAGE
+    P: BL01T-MO-MOTOR-01
     PREC: 3
     TWV: 1
     UEIP: "Yes"
@@ -68,7 +68,7 @@ entities:
     HLSV: NO_ALARM
     M: :A
     MRES: 0.018
-    P: BL01T-MO-MAP-01:STAGE
+    P: BL01T-MO-MOTOR-01
     PREC: 3
     TWV: 18
     UEIP: "Yes"

--- a/example/bl01t-services/synoptic/techui.yaml
+++ b/example/bl01t-services/synoptic/techui.yaml
@@ -22,7 +22,7 @@ components:
     prefix: BL01T-EA-PILAT-01
 
   motor:
-    desc: Hexapod Stage
-    prefix: BL01T-MO-MAP-01:STAGE
+    desc: Motor Stage
+    prefix: BL01T-MO-MOTOR-01
     extras:
       - BL01T-MO-BRICK-01

--- a/src/techui_builder/builder.py
+++ b/src/techui_builder/builder.py
@@ -57,6 +57,8 @@ class Builder:
         # Requires beamline has already been read from create_gui.yaml
         self._services_dir = Path(f"{self.beamline.dom}-services/services")
 
+        self.generator = Generator(self._services_dir.parent)
+
     def _extract_from_create_gui(self):
         """
         Extracts from the create_gui.yaml file to generate
@@ -120,9 +122,9 @@ Does it exist?"
                     self.entities[new_entity.P].append(new_entity)
 
     def _generate_screen(self, screen_name: str, screen_components: list[Entity]):
-        generator = Generator(screen_components, screen_name, self._services_dir.parent)
-        generator.build_groups()
-        generator.write_screen(self._write_directory)
+        self.generator.load_screen(screen_name, screen_components)
+        self.generator.build_groups()
+        self.generator.write_screen(self._write_directory)
 
     def generate_screens(self):
         """Generate the screens for each component in techui.yaml"""

--- a/src/techui_builder/builder.py
+++ b/src/techui_builder/builder.py
@@ -128,7 +128,7 @@ Does it exist?"
 
     def generate_screens(self):
         """Generate the screens for each component in techui.yaml"""
-        if self.entities is None:
+        if len(self.entities) == 0:
             LOGGER.critical("No ioc entities found, has setup() been run?")
             exit()
 

--- a/src/techui_builder/generate.py
+++ b/src/techui_builder/generate.py
@@ -17,10 +17,10 @@ LOGGER = logging.getLogger(__name__)
 
 @dataclass
 class Generator:
-    screen_components: list[Entity]
-    # TODO: Fix type of screen
-    screen_name: str
     services_dir: Path = field(repr=False)
+
+    screen_name: str = field(init=False)
+    screen_components: list[Entity] = field(init=False)
 
     # These are global params for the class (not accessible by user)
     ibek_map: dict = field(init=False, repr=False)
@@ -40,17 +40,21 @@ class Generator:
     group_padding: int = field(default=50, init=False, repr=False)
 
     def __post_init__(self):
-        self._read_gui_map()
+        self._read_map()
 
-    def _read_gui_map(self):
+    def _read_map(self):
         """Read the ibek-mapping.yaml file from techui-support."""
         ibek_map = self.services_dir.parent.parent.joinpath(
             "src/techui_support/ibek_mapping.yaml"
-        )
+        ).absolute()
         LOGGER.debug(f"ibek_mapping.yaml location: {ibek_map}")
 
         with open(ibek_map) as map:
             self.ibek_map = yaml.safe_load(map)
+
+    def load_screen(self, screen_name: str, screen_components: list[Entity]):
+        self.screen_name = screen_name
+        self.screen_components = screen_components
 
     def _get_screen_dimensions(self, file: str) -> tuple[int, int]:
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+import pytest
+
+from techui_builder.builder import Builder
+
+
+@pytest.fixture
+def builder():
+    path = Path("example/bl01t-services/synoptic/techui.yaml")
+    b = Builder(path)
+    b._services_dir = Path("example/bl01t-services/services")
+    b._write_directory = b._services_dir.parent.joinpath("synoptic/opis")
+    return b

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -7,12 +7,12 @@ import pytest
 @pytest.mark.parametrize(
     "attr, expected",
     [
-        ("beamline.dom", "bl01t"),
-        ("beamline.desc", "Test Beamline"),
+        ("dom", "bl01t"),
+        ("desc", "Test Beamline"),
     ],
 )
 def test_beamline_attributes(builder, attr, expected):
-    assert getattr(builder, attr) == expected
+    assert getattr(builder.beamline, attr) == expected
 
 
 @pytest.mark.parametrize(
@@ -22,9 +22,9 @@ def test_beamline_attributes(builder, attr, expected):
         (
             4,
             "motor",
-            "Hexapod Stage",
-            "BL01T-MO-MAP-01",
-            "STAGE",
+            "Motor Stage",
+            "BL01T-MO-MOTOR-01",
+            None,
             None,
             None,
         ),
@@ -45,12 +45,12 @@ def test_component_attributes(builder, index, name, desc, P, R, attribute, extra
     "index, type, desc, P, M, R",
     [
         (0, "pmac.GeoBrick", None, "BL01T-MO-BRICK-01", None, None),
-        (0, "pmac.autohome", None, "BL01T-MO-MAP-01:STAGE", None, None),
+        (0, "pmac.autohome", None, "BL01T-MO-MOTOR-01", None, None),
         (
             1,
             "pmac.dls_pmac_asyn_motor",
             None,
-            "BL01T-MO-MAP-01:STAGE",
+            "BL01T-MO-MOTOR-01",
             "X",
             None,
         ),
@@ -58,13 +58,16 @@ def test_component_attributes(builder, index, name, desc, P, R, attribute, extra
             2,
             "pmac.dls_pmac_asyn_motor",
             None,
-            "BL01T-MO-MAP-01:STAGE",
+            "BL01T-MO-MOTOR-01",
             "A",
             None,
         ),
     ],
 )
 def test_gb_extract_entities(builder, index, type, desc, P, M, R):
+    builder._extract_entities(
+        builder._services_dir.joinpath("bl01t-mo-ioc-01/config/ioc.yaml")
+    )
     entity = builder.entities[P][index]
     assert entity.type == type
     assert entity.desc == desc

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -3,17 +3,6 @@ from pathlib import Path
 
 import pytest
 
-from techui_builder.builder import Builder
-
-
-@pytest.fixture
-def gb():
-    path = Path("example/bl01t-services/synoptic/create_gui.yaml")
-    b = Builder(path)
-    b._services_dir = Path("./example/bl01t-services/services")
-    b.setup()
-    return b
-
 
 @pytest.mark.parametrize(
     "attr, expected",
@@ -22,8 +11,8 @@ def gb():
         ("beamline.desc", "Test Beamline"),
     ],
 )
-def test_beamline_attributes(gb: Builder, attr, expected):
-    assert eval(f"gb.{attr}") == expected
+def test_beamline_attributes(builder, attr, expected):
+    assert getattr(builder, attr) == expected
 
 
 @pytest.mark.parametrize(
@@ -41,8 +30,8 @@ def test_beamline_attributes(gb: Builder, attr, expected):
         ),
     ],
 )
-def test_component_attributes(gb: Builder, index, name, desc, P, R, attribute, extras):
-    component = gb.components[index]
+def test_component_attributes(builder, index, name, desc, P, R, attribute, extras):
+    component = builder.components[index]
     assert component.name == name
     assert component.desc == desc
     assert component.P == P
@@ -75,8 +64,8 @@ def test_component_attributes(gb: Builder, index, name, desc, P, R, attribute, e
         ),
     ],
 )
-def test_gb_extract_entities(gb: Builder, index, type, desc, P, M, R):
-    entity = gb.entities[P][index]
+def test_gb_extract_entities(builder, index, type, desc, P, M, R):
+    entity = builder.entities[P][index]
     assert entity.type == type
     assert entity.desc == desc
     assert entity.P == P
@@ -84,17 +73,16 @@ def test_gb_extract_entities(gb: Builder, index, type, desc, P, M, R):
     assert entity.R == R
 
 
-def test_setup(gb: Builder):
-    gb._services_dir = Path(f"example/{gb.beamline.dom}-services/services")
-    gb._write_directory = Path("example/data")
-    gb.generate_screens()
+def test_generate_screens(builder):
+    builder.setup()
+    builder.generate_screens()
 
-    with open(f"./{gb._write_directory}/motor.bob") as f:
+    with open(f"{builder._write_directory}/motor.bob") as f:
         expected = f.read()
 
-    with open("./tests/test_files/motor.bob") as f:
+    with open("tests/test_files/motor.bob") as f:
         control = f.read()
 
     assert expected == control
-    if Path.exists(Path(f"./{gb._write_directory}/motor.bob")):
-        os.remove(f"./{gb._write_directory}/motor.bob")
+    if Path.exists(Path(f"{builder._write_directory}/motor.bob")):
+        os.remove(f"{builder._write_directory}/motor.bob")

--- a/tests/test_files/motor.bob
+++ b/tests/test_files/motor.bob
@@ -11,9 +11,9 @@
         <name>X</name>
         <width>205</width>
         <height>120</height>
-        <file>../../../../src/techui_support/bob/pmac/motor_embed.bob</file>
+        <file>../../../src/techui_support/bob/pmac/motor_embed.bob</file>
         <macros>
-          <P>BL01T-MO-MAP-01:STAGE</P>
+          <P>BL01T-MO-MOTOR-01</P>
           <M>X</M>
         </macros>
         <x>0</x>
@@ -23,9 +23,9 @@
         <name>A</name>
         <width>205</width>
         <height>120</height>
-        <file>../../../../src/techui_support/bob/pmac/motor_embed.bob</file>
+        <file>../../../src/techui_support/bob/pmac/motor_embed.bob</file>
         <macros>
-          <P>BL01T-MO-MAP-01:STAGE</P>
+          <P>BL01T-MO-MOTOR-01</P>
           <M>A</M>
         </macros>
         <x>0</x>
@@ -43,7 +43,7 @@
             <macros>
               <P>BL01T-MO-BRICK-01</P>
             </macros>
-            <file>../../../../src/techui_support/bob/pmac/pmacController.bob</file>
+            <file>../../../src/techui_support/bob/pmac/pmacController.bob</file>
             <target>tab</target>
           </action>
         </actions>

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,21 +1,10 @@
-from pathlib import Path
+# from pathlib import Path
 
-import pytest
+# import pytest
 
-from techui_builder.builder import Builder
+# from techui_builder.builder import Builder
 
 # from techui_builder.generate import Generator
-
-
-@pytest.fixture
-def gb():
-    b = Builder(Path("example/create_gui.yaml)"))
-    b._services_dir = Path(f"./example/{b.beamline.dom}-services")
-    b._write_directory = Path("example/")
-    b._extract_entities(
-        ioc_yaml=Path(f"{b._services_dir}/services/bl01t-mo-ioc-01/config/ioc.yaml"),
-    )  # TODO: Change from hardcoded index
-    return b
 
 
 # def test_build_groups(gb: Builder):


### PR DESCRIPTION
Currently a new `Generator` instance is created for each screen generation process. This introduces some unnecessary calls to re-read the mapping files from `techui-support`.

This PR aims to make the instanciation more efficient, by moving to only create a single `Generator` object, and just passing the screen details to it when a screen is being generated.