### PR TITLE
modified warning in generate screens in builder.py

### DIFF
--- a/src/techui_builder/builder.py
+++ b/src/techui_builder/builder.py
@@ -148,8 +148,8 @@ exist."
                 self._generate_screen(component.name, screen_entities)
             else:
                 LOGGER.warning(
-                    f"{self.techui.name}: The prefix [bold]{component.prefix}[bold] set\
- in the component [bold]{component.name}[/bold] does not match any P field in the\
+                    f"{self.techui.name}: The prefix [bold]{component.prefix}[/bold]\
+ set in the component [bold]{component.name}[/bold] does not match any P field in the\
  ioc.yaml files in services"
                 )
 


### PR DESCRIPTION
Simple change to the warning in generate_screens function in the builder module, to describe what actual prefix cannot be matching in the IOC.yaml