### PR TITLE
Added clearing to the widgets list at the start of build groups

### DIFF
--- a/src/techui_builder/generate.py
+++ b/src/techui_builder/generate.py
@@ -351,6 +351,9 @@ class Generator:
         """
         # Create screen
         self.screen_ = Screen.Screen(self.screen_name)
+        # Empty widget buffer
+        self.widgets = []
+
         # create widget and group objects
 
         # order is an enumeration of the components, used to list them,


### PR DESCRIPTION
The screens currently append the previous screens to the next one, and to resolve that, the widget buffer is cleared in the build groups function in generate.py 