### PR TITLE
Fixed the file not found error

### DIFF
--- a/src/techui_builder/__main__.py
+++ b/src/techui_builder/__main__.py
@@ -79,7 +79,12 @@ def main(
         ),
     ] = "INFO",
     schema: Annotated[
-        bool | None, typer.Option("--schema", callback=schema_callback)
+        bool | None,
+        typer.Option(
+            "--schema",
+            help="Generate schema for validating techui and ibek-mapping yaml files",
+            callback=schema_callback,
+        ),
     ] = None,
 ) -> None:
     """Default function called from cmd line tool."""

--- a/src/techui_builder/autofill.py
+++ b/src/techui_builder/autofill.py
@@ -92,9 +92,6 @@ class Autofiller:
         for macro in self.macros:
             # Get current component attribute
             component_attr = getattr(component, macro)
-            # If it is None, then it was not provided so ignore
-            if component_attr is None and macro != "desc":
-                continue
 
             # Fix to make sure widget is reverted back to widget that was passed in
             current_widget = widget
@@ -109,6 +106,7 @@ class Autofiller:
                 case "file":
                     tag_name = "file"
                     current_widget = _get_action_group(widget)
+                    component_attr = f"{component_name}.bob"
                 case _:
                     raise ValueError("The provided macro type is not supported.")
 

--- a/src/techui_builder/autofill.py
+++ b/src/techui_builder/autofill.py
@@ -106,7 +106,8 @@ class Autofiller:
                 case "file":
                     tag_name = "file"
                     current_widget = _get_action_group(widget)
-                    component_attr = f"{component_name}.bob"
+                    if component_attr is None:
+                        component_attr = f"{component_name}.bob"
                 case _:
                     raise ValueError("The provided macro type is not supported.")
 


### PR DESCRIPTION
When clicking on the synoptic trying to open the symbol link to a file, it didn't work for some reason. This fixes the error by correcting a continue that broke the loop for files with None