### PR TITLE
Rework json map path logic

### DIFF
--- a/src/techui_builder/builder.py
+++ b/src/techui_builder/builder.py
@@ -204,7 +204,7 @@ exist."
         if visited is None:
             visited = set()
 
-        current_node = JsonMap(str(screen_path.name))
+        current_node = JsonMap(str(screen_path.relative_to(self._write_directory)))
 
         abs_path = screen_path.absolute()
         dest_path = dest_path
@@ -262,7 +262,7 @@ exist."
                         next_file_path, dest_path, visited
                     )
                 else:
-                    child_node = JsonMap(str(file_path.name), exists=False)
+                    child_node = JsonMap(str(file_path), exists=False)
 
                 child_node.macros = macro_dict
                 # TODO: make this work for only list[JsonMap]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from techui_builder.validator import Validator
 
 @pytest.fixture
 def builder():
-    ixx_services = Path(__file__).parent.parent.joinpath(Path("example/t01-services"))
+    ixx_services = Path(__file__).parent.joinpath(Path("t01-services"))
     techui_path = ixx_services.joinpath("synoptic/techui.yaml")
 
     b = Builder(techui_path)
@@ -40,9 +40,7 @@ def example_json_map():
 
 @pytest.fixture
 def generator():
-    synoptic_dir = Path(__file__).parent.parent.joinpath(
-        Path("example/t01-services/synoptic")
-    )
+    synoptic_dir = Path(__file__).parent.joinpath(Path("t01-services/synoptic"))
 
     g = Generator(synoptic_dir)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,10 +29,25 @@ def builder_with_setup(builder: Builder):
 
 
 @pytest.fixture
+def builder_with_test_files(builder: Builder):
+    builder._write_directory = Path("tests/test_files/").absolute()
+
+    return builder
+
+
+@pytest.fixture
+def test_files():
+    screen_path = Path("tests/test_files/test_bob.bob").absolute()
+    dest_path = Path("tests/test_files/").absolute()
+
+    return screen_path, dest_path
+
+
+@pytest.fixture
 def example_json_map():
     # Create test json map with child json map
     test_map_child = JsonMap("test_child_bob.bob", exists=False)
-    test_map = JsonMap("tests/test_files/test_bob.bob")
+    test_map = JsonMap("test_bob.bob")
     test_map.children.append(test_map_child)
 
     return test_map

--- a/tests/t01-services
+++ b/tests/t01-services
@@ -1,0 +1,1 @@
+../example/t01-services

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -176,9 +176,8 @@ def test_write_json_map(builder):
         os.remove(dest_path)
 
 
-def test_generate_json_map(builder, example_json_map):
-    screen_path = Path("tests/test_files/test_bob.bob")
-    dest_path = Path("tests/test_files/")
+def test_generate_json_map(builder_with_test_files, example_json_map, test_files):
+    screen_path, dest_path = test_files
 
     # We don't want to access the _get_action_group function in this test
     with patch("techui_builder.builder._get_action_group") as mock_get_action_group:
@@ -186,7 +185,9 @@ def test_generate_json_map(builder, example_json_map):
         mock_xml["file"] = "test_child_bob.bob"
         mock_get_action_group.return_value = mock_xml
 
-        test_json_map = builder._generate_json_map(screen_path, dest_path)
+        test_json_map = builder_with_test_files._generate_json_map(
+            screen_path.absolute(), dest_path
+        )
 
         assert test_json_map == example_json_map
 
@@ -204,9 +205,10 @@ def test_generate_json_map(builder, example_json_map):
 #     assert test_json_map == example_json_map
 
 
-def test_generate_json_map_get_macros(builder, example_json_map):
-    screen_path = Path("tests/test_files/test_bob.bob")
-    dest_path = Path("tests/test_files/")
+def test_generate_json_map_get_macros(
+    builder_with_test_files, example_json_map, test_files
+):
+    screen_path, dest_path = test_files
 
     # Set a custom macro to test against
     example_json_map.children[0].macros = {"macro": "value"}
@@ -220,14 +222,17 @@ def test_generate_json_map_get_macros(builder, example_json_map):
         macros["macro"] = "value"
         mock_get_action_group.return_value = mock_xml
 
-        test_json_map = builder._generate_json_map(screen_path, dest_path)
+        test_json_map = builder_with_test_files._generate_json_map(
+            screen_path, dest_path
+        )
 
         assert test_json_map == example_json_map
 
 
-def test_generate_json_map_visited_node(builder, example_json_map):
-    screen_path = Path("tests/test_files/test_bob.bob")
-    dest_path = Path("tests/test_files/")
+def test_generate_json_map_visited_node(
+    builder_with_test_files, example_json_map, test_files
+):
+    screen_path, dest_path = test_files
 
     visited = {screen_path}
     # Clear children as they will never be read
@@ -235,28 +240,31 @@ def test_generate_json_map_visited_node(builder, example_json_map):
     # Need to set this to true too
     example_json_map.duplicate = True
 
-    test_json_map = builder._generate_json_map(screen_path, dest_path, visited)
+    test_json_map = builder_with_test_files._generate_json_map(
+        screen_path, dest_path, visited
+    )
 
     assert test_json_map == example_json_map
 
 
-def test_generate_json_map_xml_parse_error(builder):
-    screen_path = Path("tests/test_files/test_bob_bad.bob")
-    dest_path = Path("tests/test_files/")
+def test_generate_json_map_xml_parse_error(builder_with_test_files, test_files):
+    screen_path = Path("tests/test_files/test_bob_bad.bob").absolute()
+    _, dest_path = test_files
 
-    test_json_map = builder._generate_json_map(screen_path, dest_path)
+    test_json_map = builder_with_test_files._generate_json_map(screen_path, dest_path)
 
     assert test_json_map.error.startswith("XML parse error:")
 
 
-def test_generate_json_map_other_exception(builder):
-    screen_path = Path("tests/test_files/test_bob.bob")
-    dest_path = Path("tests/test_files/")
+def test_generate_json_map_other_exception(builder_with_test_files, test_files):
+    screen_path, dest_path = test_files
 
     with patch("techui_builder.builder._get_action_group") as mock_get_action_group:
         mock_get_action_group.side_effect = Exception("Some exception")
 
-        test_json_map = builder._generate_json_map(screen_path, dest_path)
+        test_json_map = builder_with_test_files._generate_json_map(
+            screen_path, dest_path
+        )
 
         assert test_json_map.error != ""
 
@@ -265,7 +273,7 @@ def test_serialise_json_map(example_json_map):
     json_ = _serialise_json_map(example_json_map)  # type: ignore
 
     assert json_ == {
-        "file": "tests/test_files/test_bob.bob",
+        "file": "test_bob.bob",
         "children": [{"file": "test_child_bob.bob", "exists": False}],
     }
 


### PR DESCRIPTION
This PR reworks the JsonMap logic to use relative paths to the write directory.

Depends on #162 for cleaning of generated files.