### PR TITLE
Add opis URL to Beamline model

### DIFF
--- a/example/t01-services/synoptic/techui.yaml
+++ b/example/t01-services/synoptic/techui.yaml
@@ -3,6 +3,7 @@ beamline:
   short_dom: t01
   long_dom: bl01t
   desc: Test Beamline
+  url: t01-opis.diamond.ac.uk
 
 components:
   fshtr:

--- a/src/techui_builder/models.py
+++ b/src/techui_builder/models.py
@@ -46,6 +46,7 @@ _DLS_PREFIX_RE = re.compile(
 )
 _LONG_DOM_RE = re.compile(r"^[a-zA-Z]{2}\d{2}[a-zA-Z]$")
 _SHORT_DOM_RE = re.compile(r"^[a-zA-Z]{1}\d{2}(-[0-9]{1})?$")
+_OPIS_URL_RE = re.compile(r"^(https:\/\/)?([a-z0-9]{3}-(?:[0-9]-)?opis(?:.[a-z0-9]*)*)")
 
 
 class Beamline(BaseModel):
@@ -53,6 +54,7 @@ class Beamline(BaseModel):
     long_dom: str = Field(description="Full BL domain e.g. bl23b")
     desc: str = Field(description="Description")
     model_config = ConfigDict(extra="forbid")
+    url: str = Field(description="URL of ixx-opis")
 
     @field_validator("short_dom")
     @classmethod
@@ -74,6 +76,22 @@ class Beamline(BaseModel):
             return v
 
         raise ValueError("Invalid long dom.")
+
+    @field_validator("url")
+    @classmethod
+    def check_url(cls, url: str) -> str:
+        url = url.strip().lower()
+        match = _OPIS_URL_RE.match(url)
+        if match is not None and match.group(2):
+            # url in correct format
+            # e.g. t01-opis.diamond.ac.uk
+            if not match.group(1):
+                # make sure url leads with 'https://'
+                # otherwise phoebus treats it as a local file path
+                url = f"https://{match.group(2)}"
+            return url
+
+        raise ValueError("Invalid opis URL.")
 
 
 class Component(BaseModel):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,7 +10,12 @@ from techui_builder.models import (
 
 @pytest.fixture
 def beamline() -> Beamline:
-    return Beamline(short_dom="t01", long_dom="bl01t", desc="Test Beamline")
+    return Beamline(
+        short_dom="t01",
+        long_dom="bl01t",
+        desc="Test Beamline",
+        url="t01-opis.diamond.ac.uk",
+    )
 
 
 @pytest.fixture
@@ -30,6 +35,7 @@ def test_beamline_object(beamline: Beamline):
     assert beamline.short_dom == "t01"
     assert beamline.long_dom == "bl01t"
     assert beamline.desc == "Test Beamline"
+    assert beamline.url == "https://t01-opis.diamond.ac.uk"
 
 
 def test_component_object(component: Component):


### PR DESCRIPTION
This will allow for the user to manually define the URL address of the k8s opis directories.
It can also hopefully be used to help fetch the pvi screens for embedded screens.