### PR TITLE
Add IOC ibek url macro and macro validation

### DIFF
--- a/example-synoptic/b23-services/synoptic/techui-support/bob/pmac/motor_embed.bob
+++ b/example-synoptic/b23-services/synoptic/techui-support/bob/pmac/motor_embed.bob
@@ -76,7 +76,11 @@
       <name>OpenDisplay</name>
       <actions>
         <action type="open_display">
-          <file>./MOTOR.bob</file>
+          <file>$(IOC)/pmacAxis.pvi.bob</file>
+          <macros>
+            <M>:$(M)</M>
+            <P>$(P)</P>
+          </macros>
           <target>tab</target>
           <description>Open Display</description>
         </action>

--- a/src/techui_builder/builder.py
+++ b/src/techui_builder/builder.py
@@ -62,7 +62,7 @@ class Builder:
 
         self.clean_files()
 
-        self.generator = Generator(synoptic_dir)
+        self.generator = Generator(synoptic_dir, self.conf.beamline.url)
 
     def clean_files(self):
         exclude = {"index.bob"}

--- a/src/techui_builder/generate.py
+++ b/src/techui_builder/generate.py
@@ -20,6 +20,7 @@ logger_ = logging.getLogger(__name__)
 @dataclass
 class Generator:
     synoptic_dir: Path = field(repr=False)
+    beamline_url: str = field(repr=False)
 
     # These are global params for the class (not accessible by user)
     support_path: Path = field(init=False, repr=False)
@@ -220,6 +221,9 @@ class Generator:
                 new_widget.macro(
                     f"{suffix_label}", suffix.removeprefix(":").removesuffix(":")
                 )
+            # TODO: Change this to pvi_button
+            if True:
+                new_widget.macro("IOC", f"{self.beamline_url}/{component.P.lower()}")
 
         # The only other option is for related displays
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,7 @@ def example_json_map():
 def generator():
     synoptic_dir = Path(__file__).parent.joinpath(Path("t01-services/synoptic"))
 
-    g = Generator(synoptic_dir)
+    g = Generator(synoptic_dir, "test_url")
 
     return g
 
@@ -97,9 +97,10 @@ def example_embedded_widget():
     height_element = SubElement(widget_element, "height")
     height_element.text = "120"
     file_element = SubElement(widget_element, "file")
-    file_element.text = (
-        "example/t01-services/synoptic/techui-support/bob/pmac/motor_embed.bob"
-    )
+    file_element.text = "tests/test-files/motor_embed.bob"
+    macros_element = SubElement(widget_element, "macros")
+    macro_element_1 = SubElement(macros_element, "macro1")
+    macro_element_1.text = "test_macro_1"
 
     # ... which requires this horror
     widget_element = fromstring(tostring(widget_element))

--- a/tests/test_files/motor-edited.bob
+++ b/tests/test_files/motor-edited.bob
@@ -12,7 +12,7 @@
         <name>X</name>
         <width>205</width>
         <height>120</height>
-        <file>example/t01-services/synoptic/techui-support/bob/pmac/motor_embed.bob</file>
+        <file>tests/test-files/motor_embed.bob</file>
         <macros>
           <P>BL01T-MO-MOTOR-01</P>
           <M>X</M>

--- a/tests/test_files/motor_embed.bob
+++ b/tests/test_files/motor_embed.bob
@@ -76,7 +76,11 @@
       <name>OpenDisplay</name>
       <actions>
         <action type="open_display">
-          <file>./MOTOR.bob</file>
+          <file>$(IOC)/pmacAxis.pvi.bob</file>
+          <macros>
+            <M>:$(M)</M>
+            <P>$(P)</P>
+          </macros>
           <target>tab</target>
           <description>Open Display</description>
         </action>

--- a/tests/test_files/widget.xml
+++ b/tests/test_files/widget.xml
@@ -9,5 +9,6 @@
   <macros>
     <P>BL23B-DI-MOD-02</P>
     <R>CAM</R>
+    <IOC>test_url/bl23b-di-mod-02</IOC>
   </macros>
 </widget>

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -49,11 +49,12 @@ def test_validator_validate_bob(validator, example_embedded_widget):
     validator.validate = {"motor-edited": Path("tests/test_files/motor-edited.bob")}
     test_pwidget = EmbeddedDisplay(
         "motor",
-        "example/t01-services/synoptic/techui-support/bob/pmac/motor_embed.bob",
+        "tests/test-files/motor_embed.bob",
         0,
         0,
         205,
         120,
     )
+    test_pwidget.macro("macro1", "test_macro_1")
 
     validator.validate_bob("motor-edited", "motor", [test_pwidget])


### PR DESCRIPTION
The "MORE" button on embedded screens doesn't currently point to the ibek screens. This PR adds a new macro to all newly generated embedded screens to link to these.
It also adds macro validation.

Links to #186, but doesn't fix it.