### PR TITLE
Adding files in action buttons in embedded screens to JsonMap

### DIFF
--- a/src/techui_builder/builder.py
+++ b/src/techui_builder/builder.py
@@ -247,6 +247,7 @@ exist."
         """Recursively generate JSON map from .bob file tree"""
 
 <<<<<<< HEAD
+<<<<<<< HEAD
         # Create initial node at top of .bob file
         current_node = JsonMap(
             str(screen_path.relative_to(self._write_directory)),
@@ -276,6 +277,8 @@ exist."
                 return file_elem
             return file_elem
 
+=======
+>>>>>>> 934c651 (moved function)
         if visited is None:
             visited = set()
 
@@ -326,8 +329,8 @@ exist."
 =======
                         macro_dict = _get_macros(open_display)
                     case "embedded":
-                        file_elem = _extract_action_button_file_from_embedded(
-                            widget_elem.file
+                        file_elem = self._extract_action_button_file_from_embedded(
+                            widget_elem.file, dest_path
                         )
                         macro_dict = _get_macros(widget_elem)
 >>>>>>> 1c5aaf5 (Added functionality to fetch files in action buttons in embedded screens to add to the JsonMap)
@@ -370,6 +373,7 @@ exist."
 
         return current_node
 
+<<<<<<< HEAD
     def _get_macros(self, element: ObjectifiedElement):
         if hasattr(element, "macros"):
             macros = element.macros.getchildren()
@@ -420,6 +424,30 @@ exist."
 
             # Recursively fix children
             self._fix_duplicate_names(child)
+=======
+    def _extract_action_button_file_from_embedded(
+        self, file_elem: ObjectifiedElement, dest_path: Path
+    ) -> ObjectifiedElement:
+        file_path = Path(file_elem.text.strip() if file_elem.text else "")
+        file_path = dest_path.joinpath(file_path)
+        tree = objectify.parse(file_path.absolute())
+        root: ObjectifiedElement = tree.getroot()
+
+        # Find all <widget> elements
+        widgets = [
+            w
+            for w in root.findall(".//widget")
+            if w.get("type", default=None) == "action_button"
+        ]
+
+        for widget_elem in widgets:
+            open_display = _get_action_group(widget_elem)
+            if open_display is None:
+                continue
+            file_elem = open_display.file
+            return file_elem
+        return file_elem
+>>>>>>> 934c651 (moved function)
 
     def write_json_map(
         self,

--- a/src/techui_builder/builder.py
+++ b/src/techui_builder/builder.py
@@ -246,11 +246,41 @@ exist."
     def _generate_json_map(self, screen_path: Path, dest_path: Path) -> JsonMap:
         """Recursively generate JSON map from .bob file tree"""
 
+<<<<<<< HEAD
         # Create initial node at top of .bob file
         current_node = JsonMap(
             str(screen_path.relative_to(self._write_directory)),
             display_name=None,
         )
+=======
+        def _extract_action_button_file_from_embedded(
+            file_elem: ObjectifiedElement,
+        ) -> ObjectifiedElement:
+            file_path = Path(file_elem.text.strip() if file_elem.text else "")
+            file_path = dest_path.joinpath(file_path)
+            tree = objectify.parse(file_path.absolute())
+            root: ObjectifiedElement = tree.getroot()
+
+            # Find all <widget> elements
+            widgets = [
+                w
+                for w in root.findall(".//widget")
+                if w.get("type", default=None) == "action_button"
+            ]
+
+            for widget_elem in widgets:
+                open_display = _get_action_group(widget_elem)
+                if open_display is None:
+                    continue
+                file_elem = open_display.file
+                return file_elem
+            return file_elem
+
+        if visited is None:
+            visited = set()
+
+        current_node = JsonMap(str(screen_path.relative_to(self._write_directory)))
+>>>>>>> 1c5aaf5 (Added functionality to fetch files in action buttons in embedded screens to add to the JsonMap)
 
         abs_path = screen_path.absolute()
 
@@ -270,7 +300,7 @@ exist."
                 for w in root.findall(".//widget")
                 if w.get("type", default=None)
                 # in ["symbol", "embedded", "action_button"]
-                in ["symbol", "action_button"]
+                in ["symbol", "action_button", "embedded"]
             ]
 
             for widget_elem in widgets:
@@ -284,6 +314,7 @@ exist."
                         if open_display is None:
                             continue
 
+<<<<<<< HEAD
                         # Use file, name, and macro elements
                         file_elem = open_display.file
                         name_elem = widget_elem.name.text
@@ -292,6 +323,14 @@ exist."
                     # case "embedded":
                     #     file_elem = widget_elem.file
                     #     macro_dict = _get_macros(widget_elem)
+=======
+                        macro_dict = _get_macros(open_display)
+                    case "embedded":
+                        file_elem = _extract_action_button_file_from_embedded(
+                            widget_elem.file
+                        )
+                        macro_dict = _get_macros(widget_elem)
+>>>>>>> 1c5aaf5 (Added functionality to fetch files in action buttons in embedded screens to add to the JsonMap)
 
                     case _:
                         continue

--- a/src/techui_builder/builder.py
+++ b/src/techui_builder/builder.py
@@ -246,44 +246,11 @@ exist."
     def _generate_json_map(self, screen_path: Path, dest_path: Path) -> JsonMap:
         """Recursively generate JSON map from .bob file tree"""
 
-<<<<<<< HEAD
-<<<<<<< HEAD
         # Create initial node at top of .bob file
         current_node = JsonMap(
             str(screen_path.relative_to(self._write_directory)),
             display_name=None,
         )
-=======
-        def _extract_action_button_file_from_embedded(
-            file_elem: ObjectifiedElement,
-        ) -> ObjectifiedElement:
-            file_path = Path(file_elem.text.strip() if file_elem.text else "")
-            file_path = dest_path.joinpath(file_path)
-            tree = objectify.parse(file_path.absolute())
-            root: ObjectifiedElement = tree.getroot()
-
-            # Find all <widget> elements
-            widgets = [
-                w
-                for w in root.findall(".//widget")
-                if w.get("type", default=None) == "action_button"
-            ]
-
-            for widget_elem in widgets:
-                open_display = _get_action_group(widget_elem)
-                if open_display is None:
-                    continue
-                file_elem = open_display.file
-                return file_elem
-            return file_elem
-
-=======
->>>>>>> 934c651 (moved function)
-        if visited is None:
-            visited = set()
-
-        current_node = JsonMap(str(screen_path.relative_to(self._write_directory)))
->>>>>>> 1c5aaf5 (Added functionality to fetch files in action buttons in embedded screens to add to the JsonMap)
 
         abs_path = screen_path.absolute()
 
@@ -317,23 +284,17 @@ exist."
                         if open_display is None:
                             continue
 
-<<<<<<< HEAD
                         # Use file, name, and macro elements
                         file_elem = open_display.file
                         name_elem = widget_elem.name.text
                         macro_dict = self._get_macros(open_display)
 
-                    # case "embedded":
-                    #     file_elem = widget_elem.file
-                    #     macro_dict = _get_macros(widget_elem)
-=======
-                        macro_dict = _get_macros(open_display)
                     case "embedded":
                         file_elem = self._extract_action_button_file_from_embedded(
                             widget_elem.file, dest_path
                         )
-                        macro_dict = _get_macros(widget_elem)
->>>>>>> 1c5aaf5 (Added functionality to fetch files in action buttons in embedded screens to add to the JsonMap)
+                        name_elem = widget_elem.name.text
+                        macro_dict = self._get_macros(widget_elem)
 
                     case _:
                         continue
@@ -373,7 +334,29 @@ exist."
 
         return current_node
 
-<<<<<<< HEAD
+    def _extract_action_button_file_from_embedded(
+        self, file_elem: ObjectifiedElement, dest_path: Path
+    ) -> ObjectifiedElement:
+        file_path = Path(file_elem.text.strip() if file_elem.text else "")
+        file_path = dest_path.joinpath(file_path)
+        tree = objectify.parse(file_path.absolute())
+        root: ObjectifiedElement = tree.getroot()
+
+        # Find all <widget> elements
+        widgets = [
+            w
+            for w in root.findall(".//widget")
+            if w.get("type", default=None) == "action_button"
+        ]
+
+        for widget_elem in widgets:
+            open_display = _get_action_group(widget_elem)
+            if open_display is None:
+                continue
+            file_elem = open_display.file
+            return file_elem
+        return file_elem
+
     def _get_macros(self, element: ObjectifiedElement):
         if hasattr(element, "macros"):
             macros = element.macros.getchildren()
@@ -424,30 +407,6 @@ exist."
 
             # Recursively fix children
             self._fix_duplicate_names(child)
-=======
-    def _extract_action_button_file_from_embedded(
-        self, file_elem: ObjectifiedElement, dest_path: Path
-    ) -> ObjectifiedElement:
-        file_path = Path(file_elem.text.strip() if file_elem.text else "")
-        file_path = dest_path.joinpath(file_path)
-        tree = objectify.parse(file_path.absolute())
-        root: ObjectifiedElement = tree.getroot()
-
-        # Find all <widget> elements
-        widgets = [
-            w
-            for w in root.findall(".//widget")
-            if w.get("type", default=None) == "action_button"
-        ]
-
-        for widget_elem in widgets:
-            open_display = _get_action_group(widget_elem)
-            if open_display is None:
-                continue
-            file_elem = open_display.file
-            return file_elem
-        return file_elem
->>>>>>> 934c651 (moved function)
 
     def write_json_map(
         self,

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -308,7 +308,11 @@ def test_generate_json_map_embedded_screen(builder_with_test_files, example_json
 
     test_json_map = builder_with_test_files._generate_json_map(screen_path, dest_path)
     example_json_map.file = "test_bob_embedded.bob"
-    example_json_map.children.append(JsonMap("$(IOC)/pmacAxis.pvi.bob", exists=False))
+    example_json_map.children.append(
+        JsonMap(
+            "$(IOC)/pmacAxis.pvi.bob", display_name="Embedded Display", exists=False
+        )
+    )
     assert test_json_map == example_json_map
 
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -302,16 +302,14 @@ def test_generate_json_map(builder_with_test_files, example_json_map, test_files
 
 
 # TODO: write this test
-# def test_generate_json_map_embedded_screen(builder, example_json_map):
-#     screen_path = Path("tests/test_files/test_bob.bob")
-#     dest_path = Path("tests/test_files/")
+def test_generate_json_map_embedded_screen(builder_with_test_files, example_json_map):
+    screen_path = Path("tests/test_files/test_bob_embedded.bob").absolute()
+    dest_path = Path("tests/test_files/")
 
-#     # Set widget type to embedded
-#     ...
-
-#     test_json_map = builder._generate_json_map(screen_path, dest_path)
-
-#     assert test_json_map == example_json_map
+    test_json_map = builder_with_test_files._generate_json_map(screen_path, dest_path)
+    example_json_map.file = "test_bob_embedded.bob"
+    example_json_map.children.append(JsonMap("$(IOC)/pmacAxis.pvi.bob", exists=False))
+    assert test_json_map == example_json_map
 
 
 def test_parse_display_name_with_name(builder):

--- a/tests/test_files/test_bob_embedded.bob
+++ b/tests/test_files/test_bob_embedded.bob
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--Saved on 2026-01-12 10:15:49 by uns32131-->
+<display version="2.0.0">
+  <name>Display</name>
+  <widget type="symbol" version="2.0.0">
+    <name>Detector</name>
+    <pv_name>test_device</pv_name>
+    <x>60</x>
+    <y>150</y>
+    <width>50</width>
+    <height>50</height>
+    <actions>
+      <action type="open_display">
+        <description>Open Display</description>
+        <file>test_child_bob.bob</file>
+        <target>replace</target>
+      </action>
+    </actions>
+    <tooltip>$(pv_name)
+$(pv_value)
+$(actions)</tooltip>
+  </widget>
+  <widget type="embedded" version="2.0.0">
+    <name>Embedded Display</name>
+    <file>motor_embed.bob</file>
+    <x>150</x>
+    <y>120</y>
+    <width>160</width>
+    <height>80</height>
+  </widget>
+</display>


### PR DESCRIPTION
This adds the functionality to add the files in the action buttons in embedded screens without adding the actual embedded screens, but carrying over the macros to the generated JsonMap