### PR TITLE
Added conditions for branched services

### DIFF
--- a/src/techui_builder/builder.py
+++ b/src/techui_builder/builder.py
@@ -89,7 +89,7 @@ class Builder:
         logger_.info("Preserving edited screens for validation.")
         logger_.debug(f"Screens to validate: {list(self.validator.validate.keys())}")
 
-        logger_.info("Cleaning synoptic/ of generated screens.")
+        logger_.info("Cleaning synoptic directory of generated screens.")
 
         generated_files = self.generated_bobs
 

--- a/src/techui_builder/main_app.py
+++ b/src/techui_builder/main_app.py
@@ -25,22 +25,34 @@ def find_dirs(file_path: Path, beamline: str) -> tuple:
     cwd = Path.cwd()
     logger_.debug(f"Working directory: {cwd}")
 
+    directory = beamline
+
+    if not beamline.startswith("i"):
+        # If not found, try searching for Ixx-services as some
+        # J/K beamlines are in Ixx-services dir
+        directory = f"i{beamline[1:]}"
+        logger_.info(
+            f"{beamline}-services not found. Searching for I{beamline[1:]}-services..."
+        )
     # Get the relative path of ixx-services to techui.yaml
     ixx_services_dir = next(
         (
             ixx_services.relative_to(cwd, walk_up=True)
             for parent in abs_path.parents
-            for ixx_services in parent.glob(f"{beamline}-services")
+            for ixx_services in parent.glob(f"{directory}-services")
         ),
         None,
     )
+
     if ixx_services_dir is None:
-        logging.critical("ixx-services not found. Is you file structure correct?")
+        logging.critical(
+            f"{beamline}-services not found. Is you file structure correct?"
+        )
         exit()
     logger_.debug(f"ixx-services relative path: {ixx_services_dir}")
 
     # Get the synoptic dir relative to the parent dir
-    synoptic_dir = ixx_services_dir.joinpath("synoptic")
+    synoptic_dir = abs_path.parent
     logger_.debug(f"synoptic relative path: {synoptic_dir}")
 
     return ixx_services_dir, synoptic_dir

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -67,14 +67,16 @@ def test_find_dirs(caplog):
     mock_services.relative_to.return_value = Path("mock_rel_path")
     mock_parent = MagicMock(spec=Path)
     mock_parent.glob.return_value = [mock_services]
-    mock_absolute = MagicMock()
+    mock_absolute = MagicMock(spec=Path)
     mock_absolute.parents = [mock_parent]
+    mock_absolute.parent = mock_parent
     mock_path = MagicMock(spec=Path)
     mock_path.absolute.return_value = mock_absolute
 
     services, synoptic = find_dirs(mock_path, "ixx")
 
-    assert synoptic == Path("mock_rel_path/synoptic")
+    assert synoptic == mock_absolute.parent
+    assert services == Path("mock_rel_path")
 
 
 def test_find_dirs_no_ixx_services_dir(caplog):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -93,6 +93,25 @@ def test_find_dirs_no_ixx_services_dir(caplog):
     assert exc_info.value.code is None
 
 
+def test_find_dirs_jxx_services(caplog):
+    mock_services = MagicMock(spec=Path)
+    mock_services.relative_to.return_value = Path("mock_rel_path")
+    mock_parent = MagicMock(spec=Path)
+    mock_parent.glob.return_value = [mock_services]
+    mock_absolute = MagicMock(spec=Path)
+    mock_absolute.parents = [mock_parent]
+    mock_absolute.parent = mock_parent
+    mock_path = MagicMock(spec=Path)
+    mock_path.absolute.return_value = mock_absolute
+
+    with caplog.at_level(logging.INFO):
+        services, synoptic = find_dirs(mock_path, "jxx")
+
+    assert synoptic == mock_absolute.parent
+    assert services == Path("mock_rel_path")
+    assert "jxx-services not found. Searching for Ixx-services..." in caplog.text
+
+
 def test_find_bob(caplog):
     bob_file = Mock(spec=Path)
     bob_file.exists = MagicMock(return_value=True)


### PR DESCRIPTION
Added support for multiple synoptic beamlines.
- Added conditional in find-dirs in __main__.py to handle branches whose naming in the techui.yaml start with j/k
- Changed synoptic_dir to be abs_path.parent