### PR TITLE
stop the jsonmap being deleted between build and generate-jsonmap so …

### DIFF
--- a/src/techui_builder/builder.py
+++ b/src/techui_builder/builder.py
@@ -73,7 +73,7 @@ class Builder:
         )
 
     def clean_files(self):
-        exclude = {"index.bob", "JsonMap.json"}
+        exclude = {"index.bob"}
         bobs = [
             bob
             for bob in self._write_directory.glob("*.bob")

--- a/src/techui_builder/builder.py
+++ b/src/techui_builder/builder.py
@@ -73,7 +73,7 @@ class Builder:
         )
 
     def clean_files(self):
-        exclude = {"index.bob"}
+        exclude = {"index.bob", "JsonMap.json"}
         bobs = [
             bob
             for bob in self._write_directory.glob("*.bob")
@@ -91,13 +91,7 @@ class Builder:
 
         logger_.info("Cleaning synoptic/ of generated screens.")
 
-        try:
-            # Find the JsonMap file
-            json_map_file = next(self._write_directory.glob("JsonMap.json"))
-            # If it exists, we want to remove it too
-            generated_files = [*self.generated_bobs, json_map_file]
-        except StopIteration:
-            generated_files = self.generated_bobs
+        generated_files = self.generated_bobs
 
         # Remove any generated files that exist
         for file_ in generated_files:


### PR DESCRIPTION
…that the services CI can pass

For now have added a second hook to services CI to allow both build and generate-jsonmap to run in precommit. This was failing because the jsonmap was deleted after the first hook, and recreated after the second. Overwriting it instead allows the CI to pass checks at both stages

In b01-1-services .pre-commit-config.yaml (here using local techui-builder):
```
  - repo: local
    hooks:
      - id: tech-ui-build
        name: generate and validate the synoptic and component screens
        language: system
        # only do this if the techui support submodule has been added
        entry: |
          bash -c "
            if [[ -f synoptic/techui-support/techui-support.yaml ]]; then
              techui-builder build synoptic/techui.yaml
            fi"
        files: ^synoptic/
        pass_filenames: false

      - id: tech-ui-jsonmap
        name: generate jsonmap
        language: system
        entry: techui-builder generate-jsonmap synoptic/index.bob
        files: ^synoptic/
        pass_filenames: false
```