### PR TITLE
Remove interspersed args for the main app

### DIFF
--- a/src/techui_builder/__main__.py
+++ b/src/techui_builder/__main__.py
@@ -14,7 +14,6 @@ logger_ = logging.getLogger(__name__)
 
 app = typer.Typer(
     pretty_exceptions_show_locals=False,
-    context_settings={"allow_interspersed_args": True},
     help="""
     A script for building Phoebus GUIs.
 


### PR DESCRIPTION
With the setting in the main app, you cannot do things such as `-l` and `--help` for the sub apps.
The settings is enabled for the sub apps though.