### PR TITLE
Fix checking for yaml files if there are multiple

### DIFF
--- a/src/techui_builder/builder.py
+++ b/src/techui_builder/builder.py
@@ -110,7 +110,15 @@ class Builder:
             # If service doesn't exist, file open will fail throwing exception
             try:
                 service_yaml_dir = service.joinpath("config")
-                service_yaml = next(service_yaml_dir.glob("*.yaml"), None)
+
+                yaml_matches = [
+                    p
+                    for name in ("ioc.yaml", "fastcs.yaml")
+                    if (p := service_yaml_dir / name).exists()
+                ]
+                assert len(yaml_matches) <= 1
+                service_yaml = yaml_matches[0] if yaml_matches else None
+
                 if service_yaml is None:
                     raise OSError()
 
@@ -124,6 +132,11 @@ class Builder:
                     "No ioc.yaml or fastcs.yaml found for service: "
                     f"[bold]{service_name}[/bold]. Does it exist?"
                 )
+            except AssertionError:
+                logger_.critical(
+                    f"Both ioc.yaml and fastcs.yaml found for {service_name}"
+                )
+                exit()
 
     def _extract_entities(self, service_name: str, service_yaml: Path):
         """

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -146,6 +146,47 @@ def test_gb_extract_entities_fastcs_yaml(
     assert entity.macros == macros
 
 
+def test_gb_extract_services_no_yaml_files(builder, caplog, tmp_path):
+    # We don't want to use builder_with_setup as that calls _extract_services()
+    # and in turn that calls _extract_entities()
+    builder._extract_entities = Mock()
+
+    # overwrite to not see the bl01t service dirs
+    builder.conf.beamline.domain = "bl01z"
+    builder._services_dir = tmp_path
+    # Temporary files to test against
+    (tmp_path / "bl01z-ea-ioc-01").mkdir()
+    (tmp_path / "bl01z-ea-ioc-01/config").mkdir()
+
+    with pytest.raises(OSError) and caplog.at_level(logging.ERROR):
+        builder._extract_services()
+
+    for log_output in caplog.records:
+        assert ("No ioc.yaml or fastcs.yaml found for service:") in log_output.message
+
+
+def test_gb_extract_services_both_yaml_files(builder, caplog, tmp_path):
+    # We don't want to use builder_with_setup as that calls _extract_services()
+    # and in turn that calls _extract_entities()
+    builder._extract_entities = Mock()
+
+    # overwrite to not see the bl01t service dirs
+    builder.conf.beamline.domain = "bl01z"
+    builder._services_dir = tmp_path
+    # Temporary files to test against
+    (tmp_path / "bl01z-ea-ioc-01").mkdir()
+    (tmp_path / "bl01z-ea-ioc-01/config").mkdir()
+    (tmp_path / "bl01z-ea-ioc-01/config/ioc.yaml").write_text("name: test")
+    (tmp_path / "bl01z-ea-ioc-01/config/fastcs.yaml").write_text("name: other")
+
+    with caplog.at_level(logging.CRITICAL):
+        with pytest.raises(SystemExit):
+            builder._extract_services()
+
+    for log_output in caplog.records:
+        assert ("Both ioc.yaml and fastcs.yaml found for") in log_output.message
+
+
 def test_builder_generate_screen(builder_with_setup):
     # with (
     #     patch("techui_builder.builder.Generator.build_screen") as mock_build_screen,


### PR DESCRIPTION
An example for which is when there is a detectorPlugins.ibek.support.yaml for local testing.

Also added a check for if there is both an `ioc.yaml` AND a `fastcs.yaml` in a service dir.