### PR TITLE
changed from suffix to name in _update_macros

### DIFF
--- a/src/techui_builder/generate.py
+++ b/src/techui_builder/generate.py
@@ -162,11 +162,12 @@ class Generator:
             component_name = component.type
             suffix_key = suffix = ""
 
+        name = suffix.removeprefix(":").removesuffix(":")
         # Try to get name from child labels if they exist,
         # if not, just use the name as it is.
         if component.child_labels is not None:
-            if suffix in component.child_labels.keys():
-                component_name = component.child_labels[suffix]
+            if name in component.child_labels.keys():
+                component_name = component.child_labels[name]
                 self.label_flag = True
 
         prefix_key = next(k for k, v in component.macros.items() if v == prefix)

--- a/src/techui_builder/generate.py
+++ b/src/techui_builder/generate.py
@@ -162,12 +162,11 @@ class Generator:
             component_name = component.type
             suffix_key = suffix = ""
 
-        name = suffix.removeprefix(":").removesuffix(":")
         # Try to get name from child labels if they exist,
         # if not, just use the name as it is.
         if component.child_labels is not None:
-            if name in component.child_labels.keys():
-                component_name = component.child_labels[name]
+            if component_name in component.child_labels.keys():
+                component_name = component.child_labels[component_name]
                 self.label_flag = True
 
         prefix_key = next(k for k, v in component.macros.items() if v == prefix)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -198,7 +198,7 @@ def test_generator_update_macros_suffix_with_child_labels(generator):
         desc=None,
         service_name="bl01t-mo-test-01",
         macros={"P": "TEST", suffix_key: suffix},
-        child_labels={suffix: child_label},
+        child_labels={"T1": child_label},
     )
 
     component_name, updated_macros = generator._update_macros(component)


### PR DESCRIPTION
This has been changed before, but maybe the commit has been lost... basically, we remove the prefix and suffix, so we can have X as a child label, instead of :X