### PR TITLE
Added conditional for missing label

### DIFF
--- a/src/techui_builder/generate.py
+++ b/src/techui_builder/generate.py
@@ -240,6 +240,13 @@ class Generator:
             for macro, macro_val in component.macros.items():
                 new_widget.macro(macro, macro_val)
 
+            if component.macros.get("label") is None:
+                new_widget.macro(
+                    "label",
+                    list(component.macros.values())[-1]
+                    .removeprefix(":")
+                    .removesuffix(":"),
+                )
             # TODO: Change this to pvi_button
             if True:
                 new_widget.macro("IOC", f"{self.beamline_url}/{component.service_name}")


### PR DESCRIPTION
Basically added a conditional based on if the label key is missing in a component, which is required by the screens. If missing, it will fill in from the last macro in the components list, which is usually the most unique, detailing the component. 